### PR TITLE
Persist OAuth tokens after login

### DIFF
--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -19,6 +19,7 @@ class CustomOpenIDConnect extends CustomOAuth2
             // JWT token is base64url encoded
             $data = base64_decode(str_pad(strtr($payload, '-_', '+/'), strlen($payload) % 4, '=', STR_PAD_RIGHT));
             $this->storeData('user_data', $data);
+            $this->storeData('id_token', $idToken);
         } else {
             throw new Exception('No id_token was found.');
         }


### PR DESCRIPTION
## Summary
- persist ID token in CustomOpenIDConnect
- gather access tokens on authentication
- save OAuth tokens in user config for future refresh

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f1719188322abcff6127fe8e227