### PR TITLE
Fix Keycloak userinfo errors

### DIFF
--- a/lib/Provider/CustomOpenIDConnect.php
+++ b/lib/Provider/CustomOpenIDConnect.php
@@ -53,7 +53,8 @@ class CustomOpenIDConnect extends CustomOAuth2
         }
 
         $userInfoUrl = trim($this->config->get('endpoints')['user_info_url']);
-        if (!empty($userInfoUrl)) {
+        $accessToken = $this->getStoredData('access_token');
+        if (!empty($userInfoUrl) && !empty($accessToken)) {
             $profile = new Data\Collection( $this->apiRequest($userInfoUrl) );
             if (empty($userProfile->identifier)) {
                 $userProfile->identifier = $profile->get('sub');


### PR DESCRIPTION
## Summary
- skip userinfo request when access token is missing

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840666c779c8322b5a271d8f7776458